### PR TITLE
Add react-mobx-typescript example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "eslint.enable": false,
+  "importSorter.generalConfiguration.sortOnBeforeSave": false
+}

--- a/react-mobx-typescript/.gitignore
+++ b/react-mobx-typescript/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+package-lock.json
+
+tsc
+dist

--- a/react-mobx-typescript/README.md
+++ b/react-mobx-typescript/README.md
@@ -1,0 +1,22 @@
+# FullCalendar React+TypeScript Example Project
+
+An example project showing how [FullCalendar's React Connector](https://fullcalendar.io/docs/react) can be used with [TypeScript](https://www.typescriptlang.org/) and [MobX](https://mobx.js.org/) for managing the lifcycle of events outside of the Calendar component in a separate store.
+
+## Installation
+
+```bash
+git clone https://github.com/fullcalendar/fullcalendar-example-projects.git
+cd fullcalendar-example-projects/react-typescript
+npm install
+```
+
+## Build Commands
+
+```bash
+npm run start # builds and opens a web browser
+
+# other commands:
+npm run build # builds files into dist/ directory
+npm run watch # same as build, but watches for changes
+npm run clean # start fresh
+```

--- a/react-mobx-typescript/package.json
+++ b/react-mobx-typescript/package.json
@@ -1,0 +1,35 @@
+{
+  "private": true,
+  "name": "@fullcalendar-example-projects/react-mobx-typescript",
+  "title": "FullCalendar React+MobX+TypeScript Example Project",
+  "version": "0.0.0",
+  "license": "ISC",
+  "scripts": {
+    "clean": "rm -rf dist tsc",
+    "build": "webpack",
+    "watch": "webpack --watch",
+    "start": "webpack-dev-server --open"
+  },
+  "dependencies": {
+    "@fullcalendar/daygrid": "5.0.0-rc",
+    "@fullcalendar/interaction": "5.0.0-rc",
+    "@fullcalendar/react": "5.0.0-rc",
+    "@fullcalendar/timegrid": "5.0.0-rc",
+    "mobx": "^5.15.4",
+    "mobx-react-lite": "^2.0.7",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  },
+  "devDependencies": {
+    "@types/react": "^16.9.36",
+    "@types/react-dom": "^16.9.8",
+    "css-loader": "^3.0.0",
+    "html-webpack-plugin": "^4.3.0",
+    "style-loader": "^1.2.1",
+    "ts-loader": "^5.3.3",
+    "typescript": "^3.4.1",
+    "webpack": "^4.12.0",
+    "webpack-cli": "^3.3.0",
+    "webpack-dev-server": "^3.11.0"
+  }
+}

--- a/react-mobx-typescript/src/DemoApp.tsx
+++ b/react-mobx-typescript/src/DemoApp.tsx
@@ -1,0 +1,79 @@
+import { observer } from "mobx-react-lite";
+import React, { useContext } from "react";
+import FullCalendar, {
+  EventContentArg,
+  EventClickArg,
+  DateSelectArg,
+  EventChangeArg,
+} from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import timeGridPlugin from "@fullcalendar/timegrid";
+
+import { Sidebar } from "./Sidebar";
+import { eventStoreContext } from "./event-store";
+
+export const DemoApp = observer(function DemoApp() {
+  const eventStore = useContext(eventStoreContext);
+
+  function handleEventClick(clickInfo: EventClickArg) {
+    if (
+      confirm(
+        `Are you sure you want to delete the event '${clickInfo.event.title}'`
+      )
+    ) {
+      eventStore.deleteEvent(clickInfo.event.id);
+    }
+  }
+
+  function handleDateSelect(selectInfo: DateSelectArg) {
+    let title = prompt("Please enter a new title for your event");
+    const calendarApi = selectInfo.view.calendar;
+    calendarApi.unselect(); // clear date selection
+    eventStore.addEvent(selectInfo, title);
+  }
+
+  function handleEventChange(changeInfo: EventChangeArg) {
+    eventStore.changeEvent(changeInfo);
+  }
+
+  return (
+    <div className="demo-app">
+      <Sidebar />
+      <div className="demo-app-main">
+        <FullCalendar
+          plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+          headerToolbar={{
+            left: "prev,next today",
+            center: "title",
+            right: "dayGridMonth,timeGridWeek,timeGridDay",
+          }}
+          initialView="dayGridMonth"
+          editable={true}
+          selectable={true}
+          selectMirror={true}
+          dayMaxEvents={true}
+          weekends={eventStore.weekendsVisible}
+          /**
+           * slice() is used to achieve MobX observability on eventStore.events
+           * https://mobx.js.org/best/react.html#incorrect-use-an-observable-but-without-accessing-any-of-its-properties
+           */
+          events={eventStore.events.slice()} //
+          select={handleDateSelect}
+          eventContent={renderEventContent}
+          eventClick={handleEventClick}
+          eventChange={handleEventChange}
+        />
+      </div>
+    </div>
+  );
+});
+
+function renderEventContent(eventContent: EventContentArg) {
+  return (
+    <>
+      <b>{eventContent.timeText}</b>
+      <i>{eventContent.event.title}</i>
+    </>
+  );
+}

--- a/react-mobx-typescript/src/Sidebar.tsx
+++ b/react-mobx-typescript/src/Sidebar.tsx
@@ -1,0 +1,54 @@
+import React, { useContext } from "react";
+import { observer } from "mobx-react-lite";
+
+import { eventStoreContext } from "./event-store";
+import { formatDate, EventInput } from "@fullcalendar/react";
+
+export const Sidebar = observer(function Sidebar() {
+  const eventStore = useContext(eventStoreContext);
+
+  function renderSidebarEvent(event: EventInput) {
+    return (
+      <li key={event.id}>
+        <button onClick={() => eventStore.deleteEvent(event.id!)}>x</button>
+        <b>
+          {formatDate(event.start!, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })}
+        </b>
+        <i>{event.title}</i>
+      </li>
+    );
+  }
+
+  return (
+    <div className="demo-app-sidebar">
+      <div className="demo-app-sidebar-section">
+        <h2>Instructions</h2>
+        <ul>
+          <li>Select dates and you will be prompted to create a new event</li>
+          <li>Drag, drop, and resize events</li>
+          <li>Click an event to delete it</li>
+        </ul>
+      </div>
+      <div className="demo-app-sidebar-section">
+        <label>
+          <input
+            type="checkbox"
+            checked={eventStore.weekendsVisible}
+            onChange={() => {
+              eventStore.toggleWeekends();
+            }}
+          ></input>
+          toggle weekends
+        </label>
+      </div>
+      <div className="demo-app-sidebar-section">
+        <h2>All Events ({eventStore.events.length})</h2>
+        <ul>{eventStore.events.map(renderSidebarEvent)}</ul>
+      </div>
+    </div>
+  );
+});

--- a/react-mobx-typescript/src/event-store.ts
+++ b/react-mobx-typescript/src/event-store.ts
@@ -41,7 +41,6 @@ export class EventStore {
       end: selectInfo.end,
       allDay: selectInfo.allDay,
     });
-    console.log("all Events", this.events);
   }
 
   @action

--- a/react-mobx-typescript/src/event-store.ts
+++ b/react-mobx-typescript/src/event-store.ts
@@ -1,0 +1,73 @@
+import { createContext } from "react";
+import { observable, action } from "mobx";
+import { EventInput, DateSelectArg, EventChangeArg } from "@fullcalendar/react";
+
+export class EventStore {
+  @observable
+  weekendsVisible = true;
+
+  private eventGuid = 0;
+
+  @observable
+  events: EventInput[] = [
+    {
+      id: this.createEventId(),
+      title: "All-day event",
+      start: new Date(),
+      allDay: true,
+    },
+    {
+      id: this.createEventId(),
+      title: "Timed event",
+      start: new Date(),
+      allDay: false,
+    },
+  ];
+
+  getEvents(): EventInput[] {
+    return this.events;
+  }
+
+  private createEventId() {
+    return String(this.eventGuid++);
+  }
+
+  @action
+  addEvent(selectInfo: DateSelectArg, title: string | null) {
+    this.events.push({
+      id: this.createEventId(),
+      title: title || "New Event",
+      start: selectInfo.start,
+      end: selectInfo.end,
+      allDay: selectInfo.allDay,
+    });
+    console.log("all Events", this.events);
+  }
+
+  @action
+  deleteEvent(id: string) {
+    this.events.splice(
+      this.events.findIndex((e) => e.id == id),
+      1
+    );
+  }
+
+  @action
+  changeEvent(changeInfo: EventChangeArg) {
+    const newEvent = changeInfo.event;
+    const storedEvent = this.events.find((e) => e.id == changeInfo.event.id);
+    if (storedEvent) {
+      storedEvent.title = newEvent.title;
+      storedEvent.allDay = newEvent.allDay;
+      storedEvent.start = newEvent.start || storedEvent.start;
+      storedEvent.end = newEvent.end || storedEvent.end;
+    }
+  }
+
+  @action
+  toggleWeekends() {
+    this.weekendsVisible = !this.weekendsVisible;
+  }
+}
+
+export const eventStoreContext = createContext(new EventStore());

--- a/react-mobx-typescript/src/main.css
+++ b/react-mobx-typescript/src/main.css
@@ -1,0 +1,61 @@
+html,
+body,
+body > div {
+  /* the react root */
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+ul {
+  margin: 0;
+  padding: 0 0 0 1.5em;
+}
+
+li {
+  margin: 1.5em 0;
+  padding: 0;
+}
+
+b {
+  /* used for event dates/times */
+  margin-right: 3px;
+}
+
+.demo-app {
+  display: flex;
+  min-height: 100%;
+  font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.demo-app-sidebar {
+  width: 300px;
+  line-height: 1.5;
+  background: #eaf9ff;
+  border-right: 1px solid #d3e2e8;
+}
+
+.demo-app-sidebar-section {
+  padding: 2em;
+}
+
+.demo-app-sidebar button {
+  margin-right: 0.5em;
+}
+
+.demo-app-main {
+  flex-grow: 1;
+  padding: 3em;
+}
+
+.fc {
+  /* the calendar root */
+  max-width: 1100px;
+  margin: 0 auto;
+}

--- a/react-mobx-typescript/src/main.tsx
+++ b/react-mobx-typescript/src/main.tsx
@@ -1,0 +1,10 @@
+import "./main.css";
+
+import React from "react";
+import { render } from "react-dom";
+
+import { DemoApp } from "./DemoApp";
+
+document.addEventListener("DOMContentLoaded", function () {
+  render(<DemoApp />, document.body.appendChild(document.createElement("div")));
+});

--- a/react-mobx-typescript/tsconfig.json
+++ b/react-mobx-typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "es6",
+    "moduleResolution": "node",
+    "lib": ["dom", "es2015"],
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "strict": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "tsc",
+    "experimentalDecorators": true
+  },
+  "include": ["src/main.tsx"]
+}

--- a/react-mobx-typescript/webpack.config.js
+++ b/react-mobx-typescript/webpack.config.js
@@ -1,0 +1,34 @@
+const path = require('path')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const packageMeta = require('./package.json')
+
+module.exports = {
+  mode: 'development',
+  devtool: 'source-map',
+  entry: './src/main.tsx',
+  resolve: {
+    extensions: [ '.ts', '.tsx', '.js', '.jsx' ]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: 'ts-loader' // will use tsconfig.json
+      },
+      {
+        test: /\.css$/,
+        use: [ 'style-loader', 'css-loader' ]
+      }
+    ]
+  },
+  output: {
+    filename: 'main.js',
+    path: path.join(__dirname, 'dist')
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: packageMeta.title
+    })
+  ]
+}


### PR DESCRIPTION
Hi,
since examples are my favorite way to learn, I have put together a simple React + MobX (and mobx-react-lite) + Typescript example with functional components, and a naive class as the MobX store.
It should be very similar to the other React examples, with just the addition of delete buttons for events in the sidebar to demonstrate how events can be managed outside of the Calendar in a separate MobX store.

I am more than happy to make changes to it if needed, add some stuff, or document it a bit. Just let me know what you think!
