### PR TITLE
use default next.js presets

### DIFF
--- a/next/babel.config.js
+++ b/next/babel.config.js
@@ -1,9 +1,7 @@
 
 module.exports = {
 
-  presets: [
-    '@babel/preset-react' // necessary for all .jsx files
-  ],
+  presets: ['next/babel'], // default next.js presets
 
   // fullcalendar attempts to import its own CSS files, but next.js does not allow this.
   // throw away these statements before they arrive at next.js,

--- a/next/pages/_app.jsx
+++ b/next/pages/_app.jsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import '@fullcalendar/common/main.css'
-import '@fullcalendar/timegrid/main.css'
 import '../global-styles.css'
 
 export default function App({ Component, pageProps }) {

--- a/next/pages/index.jsx
+++ b/next/pages/index.jsx
@@ -1,3 +1,5 @@
+import '@fullcalendar/common/main.css'
+import '@fullcalendar/timegrid/main.css'
 import React from 'react'
 import FullCalendar from '@fullcalendar/react'
 import interactionPlugin from '@fullcalendar/interaction'


### PR DESCRIPTION
use the default next.js presets because `'@babel/preset-react'` don't include a lot of features that come out the box in nextjs.